### PR TITLE
allow for syndicate-to links eventually in user env variable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -43,6 +43,11 @@ app.use('/micropub/:targetsite', micropub({
   tokenReference: function (req) {
     return (req.targetsite.token || []).concat(config.token);
   },
+  queryHandler: function (q, req) {
+    if (q === 'syndicate-to' && req.targetsite.syndicateTo) {
+      return { 'syndicate-to': req.targetsite.syndicateTo };
+    }
+  },
   handler: function (micropubDocument, req) {
     logger.debug({ micropubDocument: JSON.stringify(micropubDocument, null, 2) }, 'Received a Micropub document');
 


### PR DESCRIPTION
Currently I am adding the links to `sites.js` 

```
syndicateTo: [
     {
       uid: 'https://brid.gy/publish/twitter',
       name: 'Bridgy: Twitter'
     },
    ]
```

that is the minimum needed for Quill to recognize.
