### PR TITLE
Move docs for configuration variables into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,86 @@
 # Micropub to GitHub
-
 [![Build Status](https://travis-ci.org/voxpelli/webpage-micropub-to-github.svg?branch=master)](https://travis-ci.org/voxpelli/webpage-micropub-to-github)
 [![Coverage Status](https://coveralls.io/repos/github/voxpelli/webpage-micropub-to-github/badge.svg?branch=master)](https://coveralls.io/github/voxpelli/webpage-micropub-to-github?branch=master)
 [![Dependency Status](https://gemnasium.com/voxpelli/webpage-micropub-to-github.svg)](https://gemnasium.com/voxpelli/webpage-micropub-to-github)
 
-An endpoint that accepts [Micropub](http://micropub.net/) requests, formats them into [Jekyll](http://jekyllrb.com/) posts and pushes them to a configured GitHub repository.
+An endpoint that accepts [Micropub](http://micropub.net/) requests, formats them into [Jekyll](http://jekyllrb.com/) posts before pushing them to a configured GitHub repository. This enables updating a Jekyll blog through a [Micropub client](https://indieweb.org/Micropub/Clients).
 
-Enables updating ones Jekyll blog through Micropub-supporting tools such as [Quill](https://quill.p3k.io/) and even through some [experimental iOS-flows](https://www.youtube.com/watch?v=CBPmSpD2jN4).
-
-The Micropub protocol is part of the [IndieWeb](https://indieweb.org/) movement.
-
-## Requirements
-
-Requires at least Node.js 6.0.0.
-
-## Setup
-
-### On Heroku:
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/voxpelli/webpage-micropub-to-github)
-
-### Elsewhere:
-
-Install it like a normal node.js application and adds the needed configuration through environment variables, either by copying the `sample.env` as `.env` and filling the values in there or by setting them through any other mechanism.
-
-### Yarn-support
-
-This project contains a [https://yarnpkg.com/](Yarn) lock file which is a faster and more secure alternative to the npm client.
-
-## Micropub endpoint discovery
-
-After a successful deploy the standard endpoint can be found at the `/micropub/main` path where you deployed the application, like eg. `https://example.com/micropub/main`.
-
-If you specified more than one site by using the `MICROPUB_SITES_JSON` variable, then each one of those will be available under the name of their key like `/micropub/key-name`.
-
-You need to add proper discovery for [your Micropub endpoint](https://indieweb.org/micropub#Endpoint_Discovery) as well as [your token endpoint](https://indieweb.org/obtaining-an-access-token#Discovery) to your site to enable tools to discover what endpoints it should talk to.
-
-## Current status
-
-**Early alpha**
-
+### _Early alpha_
 Supported:
-
 * Creation of posts
 * Uploading of media
 * Replacing an existing post with a new version
 
 Unsupported:
-
 * Partial update
 * Deletes
 
-## Configuration options
+## Requirements
+Requires at least Node.js 6.0.0.
 
-See the `sample.env` file and the comments within it to see all configuration possibilities.
+This project contains a [https://yarnpkg.com/](Yarn) lock file which is a faster and more secure alternative to the npm client.
 
-### Advanced condition based configuration
+## Installation
+Install as a normal Node.js application. Add the required [configuration](#configuration) values via environment variables or similar mechanism. Or deploy to Heroku:
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/voxpelli/webpage-micropub-to-github)
 
-Some options, like `MICROPUB_FILENAME_STYLE`, `MICROPUB_MEDIA_FILES_STYLE`, `MICROPUB_PERMALINK_STYLE` and `MICROPUB_OPTION_DERIVE_CATEGORY` can be given different configurations for different types of content by setting up conditions for when each configuration applies.
+## Endpoint discovery
+Once deployed, your Micropub endpoint can be found at `/micropub/main` e.g. `https://example.com/micropub/main`.
 
-The conditions are set up by assing the environment variables a JSON object of the format:
+If you specified more than one site using the `MICROPUB_SITES_JSON` variable, then each endpoint will be available under the name of its respective key, i.e. `/micropub/key-name`.
+
+To enable automatic discovery for your [Micropub endpoint](https://indieweb.org/micropub#Endpoint_Discovery) and [token endpoint](https://indieweb.org/obtaining-an-access-token#Discovery), you will need to add the following values to your site's `<head>`:
+
+```
+<link rel="micropub" href="https://example.com/micropub/main">
+<link rel="token_endpoint" href="https://tokens.indieauth.com/token">
+```
+
+## Configuration
+### Required values
+The following variables are required to enable a Micropub client to push content to your GitHub repository.
+
+Variable | Description
+-------- | -----------
+`MICROPUB_TOKEN_ENDPOINT` | URL to verify Micropub token. Example: `https://tokens.indieauth.com/token`
+`MICROPUB_TOKEN_ME` | URL to identify Micropub user. Example: `https://johndoe.example`
+`MICROPUB_GITHUB_TOKEN` | [GitHub access token](https://github.com/settings/tokens) to grant access to repository. Example: `12345abcde67890fghij09876klmno54321pqrst`
+`MICROPUB_GITHUB_USER` | Username/organisation that owns repository. Example: `johndoe`
+`MICROPUB_SITE_GITHUB_REPO` | GitHub repository in which site files are found. Example: `johndoe.github.io`
+`MICROPUB_SITE_URL` | URL where site is published. Example: `https://johndoe.example`
+
+### Syndication
+The following variables can be used to set [syndication target(s)](https://www.w3.org/TR/micropub/#syndication-targets).
+
+Variable | Description
+-------- | -----------
+`MICROPUB_SITE_SYNDICATE_TO_UID` | Unique identifier of syndication target. Example: `https://social.example/johndoe`
+`MICROPUB_SITE_SYNDICATE_TO_NAME` | User readable name of syndication target. Example: `@johndoe on Example Social Network`
+`MICROPUB_SITE_SYNDICATE_TO` | Complex syndication target. Provided as a JSON array, e.g.: `[{"uid":"https://social.example/johndoe","name":"@johndoe on Example Social Network","service":{"name":"Example Social Network","url":"https://social.example/","photo":"https://social.example/icon.png"},"user":{"name":"johndoe","url":"https://social.example/johndoe","photo":"https://social.example/johndoe/photo.jpg"}}]`. Not compatible with `MICROPUB_SITES_JSON`.
+
+### Output style
+The following variables allow you to configure the name and destination for files pushed to your repository. These variables will also accept conditional values ([described below](#conditional-values)).
+
+Variable | Description
+-------- | -----------
+`MICROPUB_FILENAME_STYLE` | File name and path for post.  Example: `_posts/:year-:month-:day-:slug`
+`MICROPUB_MEDIA_FILES_STYLE` | File name and path for media files. Example: `media/:year-:month-:slug/:filesslug`
+`MICROPUB_PERMALINK_STYLE` | [Jekyll permalink style](http://jekyllrb.com/docs/permalinks/). Example: `/:categories/:year/:month/:title/`
+`MICROPUB_OPTION_DERIVE_CATEGORY` | Override the default category
+
+### Complex configuration
+Variable | Description
+-------- | -----------
+`MICROPUB_SITES_JSON` | Complex settings and/or multiple sites (including their syndication targets) provided as JSON, e.g.: `'{"site1":{"url":"https://site1.example/","github":{"repo":"site1"},"token":[{"endpoint":"https://tokens.indieauth.com/token","me":"https://site1.example/"}]},"site2":{"url":"http://site2.example/","github":{"repo":"site2"},"token":[{"endpoint":"https://tokens.indieauth.com/token","me":"http://site2.example/"}]}}'`
+`MICROPUB_OPTION_NO_AUTO_CONFIGURE` | Auto-configure permalink status from the Jekyll repo config. Boolean
+`MICROPUB_OPTION_DERIVE_LANGUAGES` | Comma separated list of language codes to auto-detect. Example `eng,swe`
+`MICROPUB_HOST` | Domain name to enforce. Will redirect requests to all other domain names and IP addresses that the endpoint can be accessed on.
+
+### Conditional values
+Options like `MICROPUB_FILENAME_STYLE`, `MICROPUB_MEDIA_FILES_STYLE`, `MICROPUB_PERMALINK_STYLE` and `MICROPUB_OPTION_DERIVE_CATEGORY` can be given different configurations for different types of content by setting up conditions for when each configuration applies.
+
+Conditions are set up by assessing the environment variables using a JSON object of the format:
 
 ```json
 [
@@ -75,21 +95,17 @@ The conditions are set up by assing the environment variables a JSON object of t
 ]
 ```
 
-The conditions are [fulfills expressions](https://github.com/voxpelli/node-fulfills#condition-syntax) that the fulfills module will apply against the properties of the document to be saved, so pretty much all properties that's going to be inserted inte the YAML Front Matter are available to be matched against. All values explicitly set in the Micropub request are availablr, but some defaults and derived values may or may not be available, depending on option configured.
+Conditions are [fulfills expressions](https://github.com/voxpelli/node-fulfills#condition-syntax) that apply to the properties of the document being saved. Pretty much any property that can be inserted into a YAML front matter can be matched against. All values explicitly set in the Micropub request are available, but some defaults and derived values may not be available, depending on the option configured.
 
-#### Examples of conditions
-
-* _Please open an issue and ask what condition you would want to set up_
+_Please [open an issue](https://github.com/voxpelli/webpage-micropub-to-github/issues/new) and let me know what conditions you would like to set up._
 
 ## Modules used
-
-* [micropub-express](https://github.com/voxpelli/node-micropub-express) – an [Express](http://expressjs.com/) Micropub endpoint that accepts and verifies Micropub requests and calls a callback with a parsed `micropubDocument`
-* [format-microformat](https://github.com/voxpelli/node-format-microformat) – a module that takes a `micropubDocument` as its input and then formats filenames, URL:s and file content from that data to a standard format which one then can publish elsewhere. Currently supports just a single Jekyll format.
-* [github-publish](https://github.com/voxpelli/node-github-publish) – a module that takes a filename and content and publishes that to a GitHub repository. A useful place to send the formatted data that comes out of `format-microformat` to publish it to a GitHub hosted Jekyll blog like eg. a [GitHub Pages](https://pages.github.com/) one.
+* [micropub-express](https://github.com/voxpelli/node-micropub-express) – an [Express](http://expressjs.com/) Micropub endpoint that accepts and verifies Micropub requests and calls a callback with a parsed `micropubDocument`.
+* [format-microformat](https://github.com/voxpelli/node-format-microformat) – a module that takes a `micropubDocument` as its input, and converts this data into a standard that can be published elsewhere. Currently supports the Jekyll format.
+* [github-publish](https://github.com/voxpelli/node-github-publish) – a module that takes a filename and content and publishes it to a GitHub repository. The formatted data generated by `format-microformat` can be published to a Jekyll blog hosted on a GitHub, or a [GitHub Pages](https://pages.github.com/) site.
 
 ## Related
-
-* [My 2015 in IndieWeb](http://voxpelli.com/2016/03/my-2015-in-indieweb/) post from 2016-03-12 by @voxpelli
+* [My 2015 in IndieWeb](http://voxpelli.com/2016/03/my-2015-in-indieweb/) – post from 2016-03-12 by @voxpelli
 * [miklb/jekyll-indieweb](https://github.com/miklb/jekyll-indieweb) – a Jekyll theme built with the IndieWeb in mind
 * [voxpelli/voxpelli.github.com](https://github.com/voxpelli/voxpelli.github.com) – first Jekyll blog to use this Micropub endpoint
 * [webmention.herokuapp.com](https://webmention.herokuapp.com/) – another IndieWeb project suited for Jekyll, this one for [Webmention](https://indieweb.org/webmention)

--- a/sample.env
+++ b/sample.env
@@ -1,27 +1,10 @@
-MICROPUB_GITHUB_TOKEN="abc123"  # An OAuth token that givces access to the GitHub repository in which the Jekyll page can be found
-MICROPUB_GITHUB_USER="voxpelli" # The username/organisation of the one owning the GitHub repository in which the Jekyll page can be found
+# See README.md for list of available configuration options
 
-MICROPUB_TOKEN_ENDPOINT="https://tokens.indieauth.com/token" # Where a token should be verified
-MICROPUB_TOKEN_ME="http://kodfabrik.se/"                     # Who a token should identify to be valid
+MICROPUB_TOKEN_ENDPOINT="https://tokens.indieauth.com/token"
+MICROPUB_TOKEN_ME="https://johndoe.example"
 
-MICROPUB_SITE_URL="http://voxpelli.com/"        # The base path at which the Jekyll page is hosted
-MICROPUB_SITE_GITHUB_REPO="voxpelli.github.com" # The name of the GitHub repository in which the Jekyll page can be found
-# MICROPUB_SITE_SYNDICATE_TO_UID="abc123"         # Unique identifier of the syndication target, see: https://www.w3.org/TR/micropub/#syndication-targets
-# MICROPUB_SITE_SYNDICATE_TO_NAME="Readable Name" # User readable name of the syndication target, see: https://www.w3.org/TR/micropub/#syndication-targets
-MICROPUB_OPTION_DERIVE_LANGUAGES="eng,swe"      # Comma separated list of language codes to auto-detect
-# MICROPUB_HOST="example.com"                   # If set, then the specified domain name will be enforced by redirecting requests to all other domain names / IP-adresses that the endpoint can be access on
-# MICROPUB_OPTION_NO_AUTO_CONFIGURE=true        # Whether to auto-configure permalink status from the Jekyll repo config or not
+MICROPUB_GITHUB_TOKEN="12345abcde67890fghij09876klmno54321pqrst"
+MICROPUB_GITHUB_USER="johndoe"
 
-# The options MICROPUB_FILENAME_STYLE, MICROPUB_MEDIA_FILES_STYLE, MICROPUB_PERMALINK_STYLE can all also use the format of MICROPUB_OPTION_DERIVE_CATEGORY to do more advanced formatting
-# MICROPUB_FILENAME_STYLE="_posts/:year-:month-:day-:slug"         # Sets the filename style of posts
-# MICROPUB_MEDIA_FILES_STYLE="media/:year-:month-:slug/:filesslug" # Sets the filename style of media files
-# MICROPUB_PERMALINK_STYLE="/:categories/:year/:month/:title/"     # Sets the Jekyll permalink style
-
-# If you want to define more complex syndication targets as per https://www.w3.org/TR/micropub/#syndication-targets, then define it as JSON like (not compatible with MICROPUB_SITES_JSON):
-# MICROPUB_SITE_SYNDICATE_TO='[{"uid":"https://myfavoritesocialnetwork.example/aaronpk","name":"aaronpk on myfavoritesocialnetwork","service":{"name":"My Favorite Social Network","url":"https://myfavoritesocialnetwork.example/","photo":"https://myfavoritesocialnetwork.example/img/icon.png"},"user":{"name":"aaronpk","url":"https://myfavoritesocialnetwork.example/aaronpk","photo":"https://myfavoritesocialnetwork.example/aaronpk/photo.jpg"}}]'
-
-# If you want to define more complex settings and/or multiple sites, including any syndication targets of them, then use JSON such as:
-# MICROPUB_SITES_JSON='{"test":{"url":"http://micropub-test-blog.voxpelli.com/","github":{"repo":"webpage-micropub-test"},"token":[{"endpoint":"https://tokens.indieauth.com/token","me":"http://micropub-test-blog.voxpelli.com/"}]},"voxpelli.com":{"url":"http://voxpelli.com/","github":{"repo":"voxpelli.github.com"},"token":[{"endpoint":"https://tokens.indieauth.com/token","me":"http://micropub-discovery.voxpelli.com/"}]}}'
-
-# To override the default category, set to a JSON array with a value and condition key with the value being the category to use and the condition being a string condition that can be sent into the "fulfills" module: https://www.npmjs.com/package/fulfills
-# MICROPUB_OPTION_DERIVE_CATEGORY='[{"value":"category-name","condition":"bookmark OR name"}]'
+MICROPUB_SITE_URL="https://johndoe.example"
+MICROPUB_SITE_GITHUB_REPO="johndoe.github.io"


### PR DESCRIPTION
I hope you don’t mind, but I want to suggest moving documentation about the various configuration variables out of sample.env, and move the into the README. This should make it easier to explain in more detail about  the various options that can be configured. It also makes these settings more visible to new users.

The table works as a good format for displaying the different variables, though it gets a bit tricker with the large JSON examples! Might need to rethink their presentation.

I also added a bit more detail about the code you need to add to the `head` of a document in order to expose your Micropub endpoint and token, corrected a few typos and rewrote some passages.

Do let me know if you think this improves the usability of the docs, and if the changes I’ve made are correct.

