### PR TITLE
Opt-out option for HTML encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Variable | Description
 `MICROPUB_OPTION_NO_AUTO_CONFIGURE` | Auto-configure permalink status from the Jekyll repo config. Boolean
 `MICROPUB_OPTION_DERIVE_LANGUAGES` | Comma separated list of language codes to auto-detect. Example `eng,swe`
 `MICROPUB_HOST` | Domain name to enforce. Will redirect requests to all other domain names and IP addresses that the endpoint can be accessed on.
+`MICROPUB_ENCODE_HTML` | Option to opt out of HTML-encoding of text content if set to `false`. Defaults to `true`.
 
 ### Conditional values
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,7 +52,8 @@ const config = {
     layoutName: parseJSON(env[prefix + 'LAYOUT_NAME'], true),
     filenameStyle: parseJSON(env[prefix + 'FILENAME_STYLE'], true),
     mediaFilesStyle: parseJSON(env[prefix + 'MEDIA_FILES_STYLE'], true),
-    permalinkStyle: parseJSON(env[prefix + 'PERMALINK_STYLE'], true)
+    permalinkStyle: parseJSON(env[prefix + 'PERMALINK_STYLE'], true),
+    encodeHTML: env[prefix + 'ENCODE_HTML'] === undefined ? true : env[prefix + 'ENCODE_HTML']
   }
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,7 @@ const config = {
     filenameStyle: parseJSON(env[prefix + 'FILENAME_STYLE'], true),
     mediaFilesStyle: parseJSON(env[prefix + 'MEDIA_FILES_STYLE'], true),
     permalinkStyle: parseJSON(env[prefix + 'PERMALINK_STYLE'], true),
-    encodeHTML: env[prefix + 'ENCODE_HTML'] === undefined ? true : env[prefix + 'ENCODE_HTML']
+    encodeHTML: parseJSON(env[prefix + 'ENCODE_HTML'])
   }
 };
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -72,7 +72,8 @@ module.exports = function (githubTarget, micropubDocument, siteUrl, options) {
       permalinkStyle: options.permalinkStyle,
       filenameStyle: options.filenameStyle,
       filesStyle: options.mediaFilesStyle,
-      layoutName: options.layoutName
+      layoutName: options.layoutName,
+      encodeHTML: options.encodeHTML
     }))
     .then(formatter => formatter.formatAll(micropubDocument))
     .then(formatted => {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -30,7 +30,7 @@ const matchPropertiesToConditions = function (conditions, properties) {
 };
 
 module.exports = function (githubTarget, micropubDocument, siteUrl, options) {
-  options = removeEmptyValues(options || {}, ['layoutName']);
+  options = removeEmptyValues(options || {}, ['layoutName', 'encodeHTML']);
 
   const publisher = new GitHubPublisher(githubTarget.token, githubTarget.user, githubTarget.repo, githubTarget.branch);
 

--- a/test/handler.spec.js
+++ b/test/handler.spec.js
@@ -471,5 +471,22 @@ describe('Handler', function () {
         filename: 'second/awesomeness-is-awesome.md'
       });
     });
+
+    it('should support encode-HTML opt out', function () {
+      handlerConfig.encodeHTML = false;
+
+      return basicTest({
+        content: (
+          '---\n' +
+          'layout: micropubpost\n' +
+          'date: \'2015-06-30T14:19:45.000Z\'\n' +
+          'title: awesomeness is awesome\n' +
+          'lang: en\n' +
+          'slug: awesomeness-is-awesome\n' +
+          '---\n' +
+          'hello world\n'
+        )
+      });
+    });
   });
 });


### PR DESCRIPTION
Added an option that allows users to out-out of encoding HTML of content value. Reason behind this update and the approach is captured as part of the conversation on issue [#8](https://github.com/voxpelli/node-format-microformat/issues/8) on the `node-format-microformat` repository. 

A new environment variable `MICROPUB_ENCODE_HTML` is added, which when set to `false`, disables HTML encoding of the content value.

**Dependency Note:** Before this is accepted and verified for execution, reference to the dependency `format-microformat` will have to be updated in `package.json`. Needs to be done once the pull request [#18](https://github.com/voxpelli/node-format-microformat/pull/18) is accepted.