### PR TITLE
Enable use of formatter contentSlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Variable | Description
 `MICROPUB_LAYOUT_NAME` | The name of the Jekyll layout to use for the posts. Set to `false` to have no layout be added. Defaults to `microblogpost`
 `MICROPUB_OPTION_DERIVE_CATEGORY` | Override the default category
 `MICROPUB_GITHUB_BRANCH` | Branch to use for pushes. Useful to test out if things end up where you want them to. Example: `micropub`
+`MICROPUB_CONTENT_SLUG` | Use the content of the post as the slug (first five words). Default is `true`.
 
 #### Complex output styles
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,7 +53,8 @@ const config = {
     layoutName: parseJSON(env[prefix + 'LAYOUT_NAME'], true),
     filenameStyle: parseJSON(env[prefix + 'FILENAME_STYLE'], true),
     mediaFilesStyle: parseJSON(env[prefix + 'MEDIA_FILES_STYLE'], true),
-    permalinkStyle: parseJSON(env[prefix + 'PERMALINK_STYLE'], true)
+    permalinkStyle: parseJSON(env[prefix + 'PERMALINK_STYLE'], true),
+    contentSlug: parseJSON(env[prefix + 'CONTENT_SLUG'], true)
   }
 };
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -72,7 +72,8 @@ module.exports = function (githubTarget, micropubDocument, siteUrl, options) {
       permalinkStyle: options.permalinkStyle,
       filenameStyle: options.filenameStyle,
       filesStyle: options.mediaFilesStyle,
-      layoutName: options.layoutName
+      layoutName: options.layoutName,
+      contentSlug: options.contentSlug
     }))
     .then(formatter => formatter.formatAll(micropubDocument))
     .then(formatted => {


### PR DESCRIPTION
Added an option to use post content as the slug. This is to address issue #90. It currently uses the first five words from the content. Would it be a good idea to allow for more variation? For example, changing the option to a numerical variable that identifies the number of words to use from the content.

There is a problem when contentSlug is true and the slug is used as part of filenameStyle (`:year-:month-:day-:slug`). Duplicate file names can occur, eg. when running server tests on https://micropub.rocks. In this case, an error is returned: `HTTP/1.1 400 Bad Request`. Would it be possible to check for duplicate filenames at the time of post creation?